### PR TITLE
Refactor codebase for cleaner architecture and remove tech debt

### DIFF
--- a/internal/files/testhelper_test.go
+++ b/internal/files/testhelper_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"os"
+	"testing"
+)
+
+// createTempFile creates a temporary file with the given content and returns its path.
+// The file is automatically cleaned up when the test completes.
+func createTempFile(t *testing.T, content string, pattern string) string {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", pattern)
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+
+	if content != "" {
+		if err := os.WriteFile(tmpFile.Name(), []byte(content), 0600); err != nil {
+			t.Fatalf("failed to write temp file: %v", err)
+		}
+	}
+	tmpFile.Close()
+
+	return tmpFile.Name()
+}
+
+// readTempFile reads and returns the content of a file.
+func readTempFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file %s: %v", path, err)
+	}
+	return string(content)
+}

--- a/internal/files/updater.go
+++ b/internal/files/updater.go
@@ -25,12 +25,12 @@ import (
 func ReadVersion(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("reading file: %w", err)
+		return "", fmt.Errorf("reading file %s: %w", path, err)
 	}
 
 	version := strings.TrimSpace(string(data))
 	if version == "" {
-		return "", fmt.Errorf("VERSION file is empty")
+		return "", fmt.Errorf("VERSION file %s is empty", path)
 	}
 
 	return version, nil
@@ -38,11 +38,10 @@ func ReadVersion(path string) (string, error) {
 
 // WriteVersion writes a version to a VERSION file.
 func WriteVersion(path, version string) error {
-	// Ensure version ends with newline
 	content := strings.TrimSpace(version) + "\n"
 
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		return fmt.Errorf("writing file: %w", err)
+		return fmt.Errorf("writing file %s: %w", path, err)
 	}
 
 	return nil

--- a/internal/files/updater_test.go
+++ b/internal/files/updater_test.go
@@ -15,7 +15,6 @@
 package files
 
 import (
-	"os"
 	"testing"
 )
 
@@ -62,18 +61,9 @@ func TestReadVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			// Create temp file
-			tmpFile, err := os.CreateTemp("", "version-*")
-			if err != nil {
-				t.Fatalf("failed to create temp file: %v", err)
-			}
-			defer os.Remove(tmpFile.Name())
+			tmpPath := createTempFile(t, tt.content, "version-*")
 
-			if err := os.WriteFile(tmpFile.Name(), []byte(tt.content), 0600); err != nil {
-				t.Fatalf("failed to write temp file: %v", err)
-			}
-
-			got, err := ReadVersion(tmpFile.Name())
+			got, err := ReadVersion(tmpPath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReadVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -120,25 +110,16 @@ func TestWriteVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			tmpFile, err := os.CreateTemp("", "version-*")
-			if err != nil {
-				t.Fatalf("failed to create temp file: %v", err)
-			}
-			defer os.Remove(tmpFile.Name())
-			tmpFile.Close()
+			tmpPath := createTempFile(t, "", "version-*")
 
-			if err := WriteVersion(tmpFile.Name(), tt.version); err != nil {
+			if err := WriteVersion(tmpPath, tt.version); err != nil {
 				t.Errorf("WriteVersion() error = %v", err)
 				return
 			}
 
-			got, err := os.ReadFile(tmpFile.Name())
-			if err != nil {
-				t.Fatalf("failed to read temp file: %v", err)
-			}
-
-			if string(got) != tt.want {
-				t.Errorf("WriteVersion() wrote %q, want %q", string(got), tt.want)
+			got := readTempFile(t, tmpPath)
+			if got != tt.want {
+				t.Errorf("WriteVersion() wrote %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/files/yaml.go
+++ b/internal/files/yaml.go
@@ -46,11 +46,8 @@ func UpdateYAMLFile(cfg VersionFileConfig, version string) error {
 		return fmt.Errorf("parsing file %s: %w", cfg.File, err)
 	}
 
-	// Apply prefix if specified
-	newValue := version
-	if cfg.Prefix != "" {
-		newValue = cfg.Prefix + version
-	}
+	// Apply prefix (empty prefix just results in version)
+	newValue := cfg.Prefix + version
 
 	// Convert dot notation path to YAML path format
 	yamlPath, err := convertToYAMLPath(cfg.Path)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -45,14 +45,38 @@ func NewClient(ctx context.Context, token string) (*Client, error) {
 }
 
 // PRRequest contains the parameters for creating a pull request.
+// All fields except Body are required.
 type PRRequest struct {
-	Owner      string
-	Repo       string
-	BaseBranch string
-	HeadBranch string
-	Title      string
-	Body       string
-	Files      []string
+	Owner      string   // GitHub repository owner (required)
+	Repo       string   // GitHub repository name (required)
+	BaseBranch string   // Base branch for the PR (required, e.g., "main")
+	HeadBranch string   // Feature branch to create (required)
+	Title      string   // PR title (required)
+	Body       string   // PR body/description
+	Files      []string // Files to commit (required, must not be empty)
+}
+
+// Validate checks that all required fields are set.
+func (r *PRRequest) Validate() error {
+	if r.Owner == "" {
+		return fmt.Errorf("owner is required")
+	}
+	if r.Repo == "" {
+		return fmt.Errorf("repo is required")
+	}
+	if r.BaseBranch == "" {
+		return fmt.Errorf("base branch is required")
+	}
+	if r.HeadBranch == "" {
+		return fmt.Errorf("head branch is required")
+	}
+	if r.Title == "" {
+		return fmt.Errorf("title is required")
+	}
+	if len(r.Files) == 0 {
+		return fmt.Errorf("at least one file is required")
+	}
+	return nil
 }
 
 // PRResult contains the result of creating a pull request.

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		token   string
+		wantErr bool
+	}{
+		{
+			name:    "valid token",
+			token:   "ghp_validtoken123",
+			wantErr: false,
+		},
+		{
+			name:    "empty token",
+			token:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client, err := NewClient(context.Background(), tt.token)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && client == nil {
+				t.Error("NewClient() returned nil client without error")
+			}
+		})
+	}
+}
+
+func TestPRRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	validRequest := PRRequest{
+		Owner:      "owner",
+		Repo:       "repo",
+		BaseBranch: "main",
+		HeadBranch: "release/v1.0.0",
+		Title:      "Release v1.0.0",
+		Body:       "Release body",
+		Files:      []string{"VERSION"},
+	}
+
+	tests := []struct {
+		name    string
+		modify  func(*PRRequest)
+		wantErr string
+	}{
+		{
+			name:    "valid request",
+			modify:  func(r *PRRequest) {},
+			wantErr: "",
+		},
+		{
+			name:    "missing owner",
+			modify:  func(r *PRRequest) { r.Owner = "" },
+			wantErr: "owner is required",
+		},
+		{
+			name:    "missing repo",
+			modify:  func(r *PRRequest) { r.Repo = "" },
+			wantErr: "repo is required",
+		},
+		{
+			name:    "missing base branch",
+			modify:  func(r *PRRequest) { r.BaseBranch = "" },
+			wantErr: "base branch is required",
+		},
+		{
+			name:    "missing head branch",
+			modify:  func(r *PRRequest) { r.HeadBranch = "" },
+			wantErr: "head branch is required",
+		},
+		{
+			name:    "missing title",
+			modify:  func(r *PRRequest) { r.Title = "" },
+			wantErr: "title is required",
+		},
+		{
+			name:    "missing files",
+			modify:  func(r *PRRequest) { r.Files = nil },
+			wantErr: "at least one file is required",
+		},
+		{
+			name:    "empty files slice",
+			modify:  func(r *PRRequest) { r.Files = []string{} },
+			wantErr: "at least one file is required",
+		},
+		{
+			name:    "body is optional",
+			modify:  func(r *PRRequest) { r.Body = "" },
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := validRequest
+			tt.modify(&req)
+
+			err := req.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error = %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				} else if err.Error() != tt.wantErr {
+					t.Errorf("Validate() error = %q, want %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -99,27 +99,23 @@ func (v *Version) Bump(bumpType string) (*Version, error) {
 // Compare compares two versions.
 // Returns -1 if v < other, 0 if v == other, 1 if v > other.
 func (v *Version) Compare(other *Version) int {
-	if v.Major != other.Major {
-		if v.Major < other.Major {
-			return -1
-		}
+	if c := cmpInt(v.Major, other.Major); c != 0 {
+		return c
+	}
+	if c := cmpInt(v.Minor, other.Minor); c != 0 {
+		return c
+	}
+	return cmpInt(v.Patch, other.Patch)
+}
+
+// cmpInt compares two integers and returns -1, 0, or 1.
+func cmpInt(a, b int) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
 		return 1
 	}
-
-	if v.Minor != other.Minor {
-		if v.Minor < other.Minor {
-			return -1
-		}
-		return 1
-	}
-
-	if v.Patch != other.Patch {
-		if v.Patch < other.Patch {
-			return -1
-		}
-		return 1
-	}
-
 	return 0
 }
 


### PR DESCRIPTION
## Summary

This PR addresses code quality issues identified during a comprehensive code review, and adds documentation explaining why releaseo is useful.

## Changes

### Documentation Added
- Added "Why Releaseo?" section explaining the problem of version drift between Helm charts and container images
- Referenced [ToolHive issue #1779](https://github.com/stacklok/toolhive/issues/1779) as original motivation
- Updated usage examples to reflect current API (`version_files`, `helm_docs_args`)
- Documented `version_files` format with examples
- Added helm-docs integration example

### Dead Code Removed
- Removed unused `GetFileContent()` function from `internal/github/pr.go`
- Removed unused `encoding/base64` import

### Code Organization (main.go)
Split large functions into smaller, focused ones:

**`run()` (was 91 lines) → now orchestrates:**
- `bumpVersion()` - version reading, parsing, and bumping
- `updateAllFiles()` - VERSION file, YAML files, and helm-docs
- `createReleasePR()` - GitHub PR creation

**`parseFlags()` (was 53 lines) → now uses:**
- `parseVersionFiles()` - JSON parsing for version files
- `resolveToken()` - token resolution from flag or env
- `parseRepository()` - repository parsing from env
- `validateConfig()` - configuration validation

### Test Improvements
- Added `internal/files/testhelper_test.go` with `createTempFile()` and `readTempFile()` helpers
- Refactored `yaml_test.go` and `updater_test.go` to use helpers (removed ~50 lines of duplication)
- Added `internal/github/client_test.go` with tests for `NewClient()` and `PRRequest.Validate()`

### Code Quality
- Added `PRRequest.Validate()` method with comprehensive field validation
- Improved error messages in `updater.go` to include file paths
- Simplified `Compare()` in `version.go` using `cmpInt()` helper
- Simplified prefix logic in `yaml.go` (removed unnecessary conditional)

## Test plan

- [x] All existing tests pass
- [x] New tests for github package pass
- [x] `go vet` reports no issues
- [x] `go build` succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)