### PR TITLE
Add security threat model documentation

### DIFF
--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -260,9 +260,6 @@ Given the maintainer-only trigger model, the following input-based threats have 
 |---------|-------------|-------------------|----------|
 | Token scope documentation | Document minimum required permissions | T5 | High |
 | Dependency scanning | Enable Dependabot/Renovate | T7 | Medium |
-| SBOM generation | Generate and publish SBOM | T7 | Medium |
-| File size limits | Add explicit limits for processed files | T6 | Low |
-| Signed releases | Sign release artifacts | T7, T8 | Medium |
 
 ## Minimum Token Permissions
 
@@ -286,18 +283,3 @@ permissions:
 - [ ] Review the allowlist of helm-docs flags if using that feature
 - [ ] Pin the action version (e.g., `@v1.0.11`) rather than using `@main`
 - [ ] Enable Dependabot for security updates
-
-## Incident Response
-
-If you discover a security vulnerability in this action:
-
-1. **Do not** open a public issue
-2. Email security@stacklok.com with details
-3. Include steps to reproduce if possible
-4. Allow 90 days for a fix before public disclosure
-
-## Version History
-
-| Version | Date | Changes |
-|---------|------|---------|
-| 1.0 | 2025-01-15 | Initial threat model |


### PR DESCRIPTION
## Summary

Adds a comprehensive security threat model for the Releaseo GitHub Action in `SECURITY.md`.

## Contents

- **Trust boundaries**: Diagrams showing where untrusted data enters the system
- **Data flow**: How inputs flow through action.yml to the Go binary
- **Asset inventory**: Critical assets (tokens, files) with sensitivity ratings
- **Threat actors**: Malicious workflow authors, PR authors, compromised dependencies, insiders
- **Threat enumeration**: 8 threats analyzed using STRIDE methodology
  - T1: Shell injection via inputs ✅ Mitigated
  - T2: Command injection via helm-docs ✅ Mitigated
  - T3: Path traversal ✅ Mitigated
  - T4: YAML injection ✅ Mitigated
  - T5: Token exposure ⚠️ Partially mitigated
  - T6: DoS via large files ⚠️ Low risk
  - T7: Supply chain attacks ⚠️ Recommendations provided
  - T8: Git branch manipulation ⚠️ Low risk
- **Security controls**: Summary of implemented and recommended controls
- **Token permissions**: Minimum required GitHub token permissions
- **User checklist**: Security best practices for action users

## Test plan

- [x] Document renders correctly in GitHub markdown
- [ ] Review by security team

🤖 Generated with [Claude Code](https://claude.com/claude-code)